### PR TITLE
add: dockerコンテナの生成とベースとなるindexページの出力ができるようにファイルの追加とコードを入力

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# 一般的な無視ファイル
+node_modules/
+*.log
+.DS_Store
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# ベースイメージに軽量なNginxを使用
+FROM nginx:alpine
+
+# publicフォルダの中身をNginxのルートディレクトリへコピー
+COPY ./public /usr/share/nginx/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"
+    volumes:
+      - ./public:/usr/share/nginx/html:ro  # :ro = 読み取り専用

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>Disappearing Todo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>タイムリミットTodo</h1>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,1 @@
+console.log("Disappearing Todo App loaded.");

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,5 @@
+body {
+  font-family: sans-serif;
+  text-align: center;
+  margin: 40px;
+}


### PR DESCRIPTION
## 概要
dockerコンテナの生成とベースとなるindexページの出力ができるようにファイルの追加とコードを入力

## 変更点

- new file:   .gitignore
- new file:   Dockerfile
- new file:   docker-compose.yml
- new file:   public/index.html
- new file:   public/script.js
- new file:   public/style.css

## 影響範囲

なし

## テスト

- dockerコンテナが正常に compose up されるのを確認
- localhostで画面表示されるのを確認

## 関連Issue

- 関連Issue: #2 